### PR TITLE
Remove dependency on time 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ homepage = "https://github.com/unrelentingtech/systemstat"
 repository = "https://github.com/unrelentingtech/systemstat"
 
 [dependencies]
-time = "0.1"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["clock"], default-features = false }
 lazy_static = "1.0"
 bytesize = "1.0"
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #[cfg(windows)]
 extern crate winapi;
 extern crate libc;
-extern crate time;
 extern crate chrono;
 extern crate bytesize;
 #[cfg_attr(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"), macro_use)]

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -1,5 +1,4 @@
 use std::{io, path};
-use time;
 use data::*;
 
 /// The Platform trait declares all the functions for getting system information.
@@ -37,7 +36,7 @@ pub trait Platform {
     /// Returns the system uptime.
     fn uptime(&self) -> io::Result<Duration> {
         self.boot_time().and_then(|bt| {
-            time::Duration::to_std(&Utc::now().signed_duration_since(bt))
+            Utc::now().signed_duration_since(bt).to_std()
                 .map_err(|_| io::Error::new(io::ErrorKind::Other, "Could not process time"))
         })
     }
@@ -45,7 +44,7 @@ pub trait Platform {
     /// Returns the system boot time.
     fn boot_time(&self) -> io::Result<DateTime<Utc>> {
         self.uptime().and_then(|ut| {
-            Ok(Utc::now() - time::Duration::from_std(ut)
+            Ok(Utc::now() - chrono::Duration::from_std(ut)
                 .map_err(|_| io::Error::new(io::ErrorKind::Other, "Could not process time"))?)
         })
     }


### PR DESCRIPTION
Time 0.1 has been deprecated for a long time and since it's only used internally and can be completely replaced by chrono, I think it should be removed.