### PR TITLE
Fix compilation on ARM64 macOS

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -121,6 +121,6 @@ fn statfs_to_fs(x: &statfs) -> Filesystem {
 
 #[link(name = "c")]
 extern "C" {
-    #[link_name = "getmntinfo$INODE64"]
+    #[cfg_attr(not(target_arch = "aarch64"), link_name = "getmntinfo$INODE64")]
     fn getmntinfo(mntbufp: *mut *mut statfs, flags: c_int) -> c_int;
 }


### PR DESCRIPTION
`getmntinfo$INODE64` fails with a link error, but `getmntinfo` works.

I think this closes #92.