### PR TITLE
add swap support

### DIFF
--- a/examples/info.rs
+++ b/examples/info.rs
@@ -64,7 +64,7 @@ fn main() {
                    battery.remaining_time.as_secs() % 60),
         Err(x) => print!("\nBattery: error: {}", x)
     }
-    
+
     match sys.on_ac_power() {
         Ok(power) => println!(", AC power: {}", power),
         Err(x) => println!(", AC power: error: {}", x)
@@ -73,6 +73,11 @@ fn main() {
     match sys.memory() {
         Ok(mem) => println!("\nMemory: {} used / {} ({} bytes) total ({:?})", saturating_sub_bytes(mem.total, mem.free), mem.total, mem.total.as_u64(), mem.platform_memory),
         Err(x) => println!("\nMemory: error: {}", x)
+    }
+
+    match sys.swap() {
+        Ok(swap) => println!("\nSwap: {} used / {} ({} bytes) total ({:?})", saturating_sub_bytes(swap.total, swap.free), swap.total, swap.total.as_u64(), swap.platform_swap),
+        Err(x) => println!("\nSwap: error: {}", x)
     }
 
     match sys.load_average() {

--- a/src/data.rs
+++ b/src/data.rs
@@ -249,6 +249,28 @@ pub struct Memory {
     pub platform_memory: PlatformMemory,
 }
 
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "android"))]
+pub type PlatformSwap = PlatformMemory;
+
+#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+pub struct PlatformSwap {
+    pub total: ByteSize,
+    pub avail: ByteSize,
+    pub used: ByteSize,
+    pub pagesize: ByteSize,
+    pub encrypted: bool,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+pub struct Swap {
+    pub total: ByteSize,
+    pub free: ByteSize,
+    pub platform_swap: PlatformSwap,
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct BatteryLife {

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -33,6 +33,19 @@ pub trait Platform {
     /// Returns a memory information object.
     fn memory(&self) -> io::Result<Memory>;
 
+    /// Returns a swap memory information object.
+    fn swap(&self) -> io::Result<Swap>;
+
+    /// Returns a swap and a memory information object.
+    /// On some platforms this is more efficient than calling memory() and swap() separately
+    /// If memory() or swap() are not implemented for a platform, this function will fail.
+    fn memory_and_swap(&self) -> io::Result<(Memory, Swap)> {
+        // Do swap first, in order to fail fast if it's not implemented
+        let swap = self.swap()?;
+        let memory = self.memory()?;
+        Ok((memory, swap))
+    }
+
     /// Returns the system uptime.
     fn uptime(&self) -> io::Result<Duration> {
         self.boot_time().and_then(|bt| {

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -104,6 +104,10 @@ impl Platform for PlatformImpl {
         })
     }
 
+    fn swap(&self) -> io::Result<Swap> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
     fn boot_time(&self) -> io::Result<DateTime<Utc>> {
         let mut data: timeval = unsafe { mem::zeroed() };
         sysctl!(KERN_BOOTTIME, &mut data, mem::size_of::<timeval>());

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -73,6 +73,19 @@ mod tests {
     }
 
     #[test]
+    fn test_swap() {
+        let swap = PlatformImpl::new().swap().unwrap();
+        assert!(swap.free <= swap.total);
+    }
+
+    #[test]
+    fn test_mem_and_swap() {
+        let (mem, swap) = PlatformImpl::new().memory_and_swap().unwrap();
+        assert!(mem.free.as_u64() > 1024 && mem.total.as_u64() > 1024);
+        assert!(swap.free <= swap.total);
+    }
+
+    #[test]
     fn test_battery_life() {
         if let Ok(bat) = PlatformImpl::new().battery_life() {
             assert!(bat.remaining_capacity <= 100.0 && bat.remaining_capacity >= 0.0);

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -76,6 +76,10 @@ impl Platform for PlatformImpl {
         })
     }
 
+    fn swap(&self) -> io::Result<Swap> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
     fn boot_time(&self) -> io::Result<DateTime<Utc>> {
         let mut data: timeval = unsafe { mem::zeroed() };
         sysctl!(KERN_BOOTTIME, &mut data, mem::size_of::<timeval>());


### PR DESCRIPTION
This PR adds `swap` to `Platform` and implements the required functionality for Linux, macOS and Windows. Further, `TryFrom` is implemented between `Memory` and `Swap` based on per-platform compatibility (Linux and Windows are supported).

Closes #93