### PR TITLE
update: replace chrono with time library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/unrelentingtech/systemstat"
 repository = "https://github.com/unrelentingtech/systemstat"
 
 [dependencies]
-chrono = { version = "0.4", features = ["clock"], default-features = false }
+time = "0.3.9"
 lazy_static = "1.0"
 bytesize = "1.1"
 libc = "0.2"
@@ -35,4 +35,4 @@ targets = [
 ]
 
 [features]
-serde = ["the_serde", "bytesize/serde", "chrono/serde"]
+serde = ["the_serde", "bytesize/serde", "time/serde"]

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,6 +8,7 @@ use std::io;
 pub use std::net::{Ipv4Addr, Ipv6Addr};
 use std::ops::Sub;
 pub use std::time::Duration;
+pub use time::OffsetDateTime;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,7 +3,6 @@
 //! They're always the same across all platforms.
 
 pub use bytesize::ByteSize;
-pub use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 pub use std::collections::BTreeMap;
 use std::io;
 pub use std::net::{Ipv4Addr, Ipv6Addr};

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -1,5 +1,4 @@
 use std::{io, path, convert::{TryFrom, TryInto}};
-use time::OffsetDateTime;
 use crate::data::*;
 
 /// The Platform trait declares all the functions for getting system information.

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -108,10 +108,11 @@ impl Platform for PlatformImpl {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 
-    fn boot_time(&self) -> io::Result<DateTime<Utc>> {
+    fn boot_time(&self) -> io::Result<OffsetDateTime> {
         let mut data: timeval = unsafe { mem::zeroed() };
         sysctl!(KERN_BOOTTIME, &mut data, mem::size_of::<timeval>());
-        Ok(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(data.tv_sec.into(), data.tv_usec as u32), Utc))
+        let ts = OffsetDateTime::from_unix_timestamp(data.tv_sec).expect("unix timestamp should be within range") + Duration::from_nanos(data.tv_usec as u64);
+        Ok(ts)
     }
 
     fn battery_life(&self) -> io::Result<BatteryLife> {
@@ -130,7 +131,7 @@ impl Platform for PlatformImpl {
 
     fn mounts(&self) -> io::Result<Vec<Filesystem>> {
         let mut mptr: *mut statfs = ptr::null_mut();
-        let len = unsafe { getmntinfo(&mut mptr, 1 as i32) };
+        let len = unsafe { getmntinfo(&mut mptr, 1_i32) };
         if len < 1 {
             return Err(io::Error::new(io::ErrorKind::Other, "getmntinfo() failed"))
         }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,7 +4,6 @@ use libc::{
     sysctlnametomib, timeval, vm_statistics64, xsw_usage, CTL_VM, HOST_VM_INFO64,
     HOST_VM_INFO64_COUNT, KERN_SUCCESS, VM_SWAPUSAGE, _SC_PHYS_PAGES,
 };
-use time::OffsetDateTime;
 use crate::data::*;
 use super::common::*;
 use super::unix;

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,6 +4,7 @@ use libc::{
     sysctlnametomib, timeval, vm_statistics64, xsw_usage, CTL_VM, HOST_VM_INFO64,
     HOST_VM_INFO64_COUNT, KERN_SUCCESS, VM_SWAPUSAGE, _SC_PHYS_PAGES,
 };
+use time::OffsetDateTime;
 use crate::data::*;
 use super::common::*;
 use super::unix;
@@ -140,10 +141,11 @@ impl Platform for PlatformImpl {
         })
     }
 
-    fn boot_time(&self) -> io::Result<DateTime<Utc>> {
+    fn boot_time(&self) -> io::Result<OffsetDateTime> {
         let mut data: timeval = unsafe { mem::zeroed() };
         sysctl!(KERN_BOOTTIME, &mut data, mem::size_of::<timeval>());
-        Ok(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(data.tv_sec.into(), data.tv_usec as u32), Utc))
+        let ts = OffsetDateTime::from_unix_timestamp(data.tv_sec).expect("unix timestamp should be within range") + Duration::from_nanos(data.tv_usec as u64);
+        Ok(ts)
     }
 
     fn battery_life(&self) -> io::Result<BatteryLife> {
@@ -156,7 +158,7 @@ impl Platform for PlatformImpl {
 
     fn mounts(&self) -> io::Result<Vec<Filesystem>> {
         let mut mptr: *mut statfs = ptr::null_mut();
-        let len = unsafe { getmntinfo(&mut mptr, 2 as i32) };
+        let len = unsafe { getmntinfo(&mut mptr, 2_i32) };
         if len < 1 {
             return Err(io::Error::new(io::ErrorKind::Other, "getmntinfo() failed"))
         }

--- a/src/platform/netbsd.rs
+++ b/src/platform/netbsd.rs
@@ -29,7 +29,7 @@ impl Platform for PlatformImpl {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 
-    fn boot_time(&self) -> io::Result<DateTime<Utc>> {
+    fn boot_time(&self) -> io::Result<OffsetDateTime> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -80,10 +80,11 @@ impl Platform for PlatformImpl {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 
-    fn boot_time(&self) -> io::Result<DateTime<Utc>> {
+    fn boot_time(&self) -> io::Result<OffsetDateTime> {
         let mut data: timeval = unsafe { mem::zeroed() };
         sysctl!(KERN_BOOTTIME, &mut data, mem::size_of::<timeval>());
-        Ok(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(data.tv_sec, data.tv_usec as u32), Utc))
+        let ts = OffsetDateTime::from_unix_timestamp(data.tv_sec).expect("unix timestamp should be within range") + Duration::from_nanos(data.tv_usec as u64);
+        Ok(ts)
     }
 
     // /dev/apm is probably the nicest interface I've seen :)


### PR DESCRIPTION
This PR replaces the `chrono` dependency with `time`. The current version of the `chrono` crate (v0.4.19) depends on an old version of the `time` crate (v0.1.43) that can segfault under certain conditions. Since `chrono` is currently unmaintained, it has been replaced with a version of the `time` crate (v0.3.9) that does not expose users to possible segfaults.