### PR TITLE
Update mod.rs

### DIFF
--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -274,10 +274,6 @@ impl Platform for PlatformImpl {
         disk::drives()
     }
 
-    fn mount_at<P: AsRef<path::Path>>(&self, _path: P) -> io::Result<Filesystem> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
-    }
-
     fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }


### PR DESCRIPTION
remove outdated Windows mount_at implementation.

There is a generic mount_at implementation in common.rs that works fine for windows mounts once the old implementation is removed.  Following example works after making this change.

```
match sys.mount_at("C:\\") {
        Ok(mount) => {
            println!("\nMount at C:\\");
            println!(
                "{} ---{}---> {} (available {} of {})",
                mount.fs_mounted_from, mount.fs_type, mount.fs_mounted_on, mount.avail, mount.total
            );
        }
        Err(x) => println!("\nMount at C:\\ error: {}", x),
    }
```